### PR TITLE
fix datetime Data Type primitive

### DIFF
--- a/Framework/src/MSODataLib/Context/ObjectContext.m
+++ b/Framework/src/MSODataLib/Context/ObjectContext.m
@@ -1736,9 +1736,9 @@
 }
 
 /*
- *convert date into proper format
+ *convert date into proper Edm.DateTime format
  *@param <date> date
- *returns date in yyyy-MM-ddTHH:mm:ss.SSSSSSS format
+ *returns date in datetime'yyyy-MM-ddTHH:mm:ss.SSSSSSS' format
  */
 
 -(NSString *) retrieveDate:(NSDate *)date
@@ -1746,7 +1746,7 @@
 	NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
 	[dateFormatter setFormatterBehavior:NSDateFormatterBehavior10_4];
 	[dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSSSSS"];
-	NSString *dateString = [dateFormatter stringFromDate:date];
+	NSString *dateString = [NSString stringWithFormat:@"datetime'%@'",[dateFormatter stringFromDate:date]];
 	[dateFormatter release];
 	
 	return dateString;


### PR DESCRIPTION
Fix issue with  Datetime primitive type on url string, see: http://odataobjc.codeplex.com/workitem/11656 

We need to add the 'datetime' literal before the value  to comply  the correct  representation

http://www.odata.org/documentation/overview/#AbstractTypeSystem
